### PR TITLE
Fix/duplicate ticket and order display

### DIFF
--- a/src/app/api/sql/getTransactions/route.ts
+++ b/src/app/api/sql/getTransactions/route.ts
@@ -45,6 +45,11 @@ export async function GET(request: Request) {
         }
 
         // Query to get transactions with their products
+        // Note: created_at / updated_at are stored as UTC strings (via toSQLDateTime → .toISOString()).
+        // UNIX_TIMESTAMP() interprets them as server-local time, so we compensate with
+        // TIMESTAMPDIFF(SECOND, UTC_TIMESTAMP(), NOW()) which equals the server UTC offset
+        // (e.g. +3600 for Europe/Paris in winter). This prevents a 1-hour gap that would cause
+        // mergeTransactionArrays to treat the same transaction as two distinct entries.
         const mainDb = process.env.DB_NAME || 'DC';
         const query = `
             SELECT 
@@ -56,8 +61,8 @@ export async function GET(request: Request) {
                 f.amount,
                 f.currency,
                 f.note,
-                UNIX_TIMESTAMP(f.created_at) * 1000 as createdDate,
-                UNIX_TIMESTAMP(f.updated_at) * 1000 as modifiedDate
+                (UNIX_TIMESTAMP(f.created_at) + TIMESTAMPDIFF(SECOND, UTC_TIMESTAMP(), NOW())) * 1000 as createdDate,
+                (UNIX_TIMESTAMP(f.updated_at) + TIMESTAMPDIFF(SECOND, UTC_TIMESTAMP(), NOW())) * 1000 as modifiedDate
             FROM facturation f
             LEFT JOIN users u ON u.id = f.user_id
             LEFT JOIN payment_methods pm ON pm.id = f.payment_method_id

--- a/src/app/components/Total.tsx
+++ b/src/app/components/Total.tsx
@@ -357,10 +357,11 @@ export const Total: FC = () => {
             if (isUpdatingTransaction(transaction) || !transaction?.amount || !isStateReady) return;
 
             openPopup(
-                (transaction.shortNumOrder ? `[#${transaction.shortNumOrder}] ` : '') +
-                    toCurrency(transaction) +
+                toCurrency(transaction) +
                     ' en ' +
-                    transaction.method,
+                    transaction.method +
+                    (transaction.shortNumOrder ? ` [#${transaction.shortNumOrder}]` : ''),
+
                 transaction.products
                     .map((product) => displayProduct(product, transaction.currency))
                     .concat(isMobileSize() ? ['', BACK_KEYWORD] : []),

--- a/src/app/contexts/DataProvider.tsx
+++ b/src/app/contexts/DataProvider.tsx
@@ -839,6 +839,8 @@ export const DataProvider: FC<DataProviderProps> = ({ children }) => {
                                     // Update the already-stored transaction with the order number
                                     transaction.shortNumOrder = counterData.short_num_order;
                                     storeTransaction(transaction);
+                                    // Persist shortNumOrder to localStorage (storeTransaction only updates React state)
+                                    setLocalStorageItem(transactionsFilename, transactions);
                                 }
                             } else {
                                 console.error('counter-order upstream error:', await counterResponse.text());


### PR DESCRIPTION
**Summary** 
Fixes two bugs in the standalone cashier ticket list (no order context). 

Bug 1 — Duplicate entries with 1-hour offset 
toSQLDateTime() stores UTC strings, but MySQL's UNIX_TIMESTAMP() reads them back in server local time (UTC+1), causing a 1-hour mismatch. mergeTransactionArrays then treated the same sale as two distinct entries. → Fixed by compensating the UTC offset in the SQL query (+ TIMESTAMPDIFF(SECOND, UTC_TIMESTAMP(), NOW())).

Bug 2 — Missing order number [#XXX] on paid tickets After a counter order, shortNumOrder was never flushed to localStorage, so it was lost on next load. The label was also prepended instead of appended in the popup title. → Fixed by persisting to localStorage after storeTransaction(), and moving [#XXX] to the end of the title.